### PR TITLE
Allow different encodings for git and local.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,10 @@ Configuration happens via JSON file. It takes the following form:
 	"project_id": "92047938-c050-4d9c-83f8-6b1d7fae6b01", // project that should be updated
 	"translation_file": "testdata/en.json", // path that contains the translations. Should be formatted like JSON-flat export of Traduora. Relative path from working directory.
 	"locale": "en", // locale to update
-	"encoding": "utf-8", // optional encoding of the translation file. Used for both the local version and the git version. If omitted, the tool tries to determine the encoding automatically via its byte order mark or just assumes UTF-8 on failure.
+	"encoding": { // The entire block as well as both property on their own are optional. If omitted, the tool tries to determine the encoding automatically via its byte order mark or just assumes UTF-8 on failure.
+		"local": "utf-16", // encoding of file stored in local file system
+		"git": "utf-8" // encoding of file stored in git
+	}
 
 	"with_ssl": true, // whether the connection to the server should be encrypted. Defaults to true.
 	"validate_certs": true, // whether the encryption certificates should be validated. Defaults to true.

--- a/traduora-update.json
+++ b/traduora-update.json
@@ -9,5 +9,8 @@
 	"with_ssl": false, // whether the connection to the server should be encrypted. Defaults to true.
 	"validate_certs": false, // whether the encryption certificates should be validated. Defaults to true.
 	"revision": "9011cdcd095d156c6a7e34182fdcba144ab1789a", // git revision to use for sanity checks to prevent wrongly changing terms. Can be any valid revision, e.g. commit hash, tag, branch. Should usually be your default branch. If omitted, sanity checks are skipped.
-	"encoding": "utf-8" // optional encoding of the translation file. Used for both the local version and the git version. If omitted, the tool tries to determine the encoding automatically via its byte order mark or just assumes UTF-8 on failure.
+	"encoding": { // optional
+		"local": "utf-16", // encoding of file stored in local file system
+		"git": "utf-8" // encoding of file stored in git
+	}
 }

--- a/traduora-update.schema.json
+++ b/traduora-update.schema.json
@@ -49,13 +49,13 @@
     "encoding": {
       "description": "Encoding of the translation file. Used for both the local version and the git version. If omitted, the tool tries to determine the encoding automatically via its byte order mark or just assumes UTF-8 on failure.",
       "writeOnly": true,
-      "examples": [
-        "utf-8",
-        "utf-16"
-      ],
-      "type": [
-        "string",
-        "null"
+      "anyOf": [
+        {
+          "$ref": "#/definitions/Encoding"
+        },
+        {
+          "type": "null"
+        }
       ]
     },
     "host": {
@@ -102,6 +102,65 @@
       "description": "Whether the connection to the server should be encrypted. Defaults to true.",
       "default": true,
       "type": "boolean"
+    }
+  },
+  "definitions": {
+    "Encoding": {
+      "anyOf": [
+        {
+          "type": "object",
+          "required": [
+            "git",
+            "local"
+          ],
+          "properties": {
+            "git": {
+              "examples": [
+                "utf-8",
+                "utf-16"
+              ],
+              "type": "string"
+            },
+            "local": {
+              "examples": [
+                "utf-8",
+                "utf-16"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "git"
+          ],
+          "properties": {
+            "git": {
+              "examples": [
+                "utf-8",
+                "utf-16"
+              ],
+              "type": "string"
+            }
+          }
+        },
+        {
+          "type": "object",
+          "required": [
+            "local"
+          ],
+          "properties": {
+            "local": {
+              "examples": [
+                "utf-8",
+                "utf-16"
+              ],
+              "type": "string"
+            }
+          }
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Fixes #11 

BREAKING CHANGES: configuration no longer supports "encoding" property
with string value, its an object now.