### PR TITLE
fix: crate did not work for windows anymore

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2128,7 +2128,7 @@ dependencies = [
 
 [[package]]
 name = "traduora-update"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "druid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "traduora-update"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.56"
 description = "A GUI application to automatically update Traduora terms from a local translation file"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,3 @@
-// On Windows platform, don't show a console when opening the app.
-#![windows_subsystem = "windows"]
-
 use anyhow::{Context, Result};
 use druid::{AppLauncher, PlatformError, WindowDesc};
 


### PR DESCRIPTION
env_logger init leads to abort if combined with #![windows_subsystem = "windows"]
See https://github.com/env-logger-rs/env_logger/issues/214 for details.